### PR TITLE
Fix event image URL field

### DIFF
--- a/src/app/calendar/public/[slugOrId]/page.tsx
+++ b/src/app/calendar/public/[slugOrId]/page.tsx
@@ -27,7 +27,7 @@ export default async function PublicCalendarPage({ params }: PublicCalendarPageP
     id: event.id,
     title: event.title,
     description: event.description || '',
-    imageUrl: event.location || '', // Using location field for image URL
+    imageUrl: event.image_url || '',
     date: new Date(event.start_time).toISOString().split('T')[0], // Convert timestamp to date string
     color: event.color || undefined,
   }))

--- a/src/components/EventCreateModal.tsx
+++ b/src/components/EventCreateModal.tsx
@@ -219,7 +219,7 @@ export default function EventCreateModal({
           {
             title: formData.title.trim(),
             description: formData.description.trim(),
-            location: formData.imageUrl.trim() || null,
+            image_url: formData.imageUrl.trim() || null,
             start_time: new Date(formData.date + "T00:00:00Z").toISOString(),
             end_time: new Date(formData.date + "T23:59:59Z").toISOString(),
             created_by: userId,

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -174,7 +174,7 @@ const Calendar = forwardRef<CalendarRef, CalendarProps>(({
           id: String(event.id),
           title: String(event.title),
           description: String(event.description || ""),
-          imageUrl: event.location ? String(event.location) : "", // Using location field for image URL
+          imageUrl: event.image_url ? String(event.image_url) : "",
           date: new Date(String(event.start_time)).toISOString().split("T")[0], // Convert timestamp to date string
           color: event.color ? String(event.color) : undefined,
         })) || [];

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -40,6 +40,7 @@ export interface PublicEvent {
   start_time: string;
   end_time?: string;
   location?: string;
+  image_url?: string;
   color?: string;
   created_at: string;
 }


### PR DESCRIPTION
## Summary
- use `image_url` when creating events
- read `image_url` when mapping event data
- expose `image_url` in PublicEvent type

## Testing
- `npm run lint`
- `npm run build` *(fails: Missing Supabase environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_686d325af73c832b996e1b31619c24c0